### PR TITLE
Fix invalid puzzles taking too long to not solve

### DIFF
--- a/test/sudoku/Sudoku.test.js
+++ b/test/sudoku/Sudoku.test.js
@@ -8,6 +8,14 @@ import {
 } from '../../index.js';
 import puzzles from './puzzles24.js';
 
+const invalidPuzzles = [
+  // Invalid because of digit clashing (col 7: 3...5.3.1)
+  '1.2....3..9..1.........3..1.15...4...2.1...5.8.....1.6..1....3......1...2......1.',
+
+  // Invalid because cell 0 has no candidates
+  '.123456789...1...........1.1...........1...........1....1...........1...........1'
+];
+
 describe('Sudoku', () => {
   describe('static', () => {
     test('mask', () => {
@@ -82,6 +90,39 @@ describe('Sudoku', () => {
       expect(numSolutionsFound).toBe(numSolutions);
     });
   });
+
+  describe('when sudoku is invalid', () => {
+    test('searchForSolutions2 finds no solution in under 1 second or pizza is free', () => {
+      invalidPuzzles.forEach(puzzleStr => {
+        let count = 0;
+        let solutions = [];
+        const startTime = Date.now();
+        new Sudoku(puzzleStr).searchForSolutions2({
+          solutionFoundCallback: (s) => {
+            count++;
+            solutions.push(s);
+            return count <= 1;
+          }
+        });
+        const timeSpent = Date.now() - startTime;
+        expect(count).toBe(0);
+        expect(timeSpent).toBeLessThan(1000);
+      });
+    });
+
+    test('firstSolution returns null', () => {
+      invalidPuzzles.forEach(p => { expect(new Sudoku(p).firstSolution()).toBeNull(); });
+    });
+
+    test('solve returns false', () => {
+      invalidPuzzles.forEach(p => { expect(new Sudoku(p).solve()).toBe(false); });
+    });
+
+    test('solutionsFlag returns 0', () => {
+      invalidPuzzles.forEach(p => { expect(new Sudoku(p).solutionsFlag()).toBe(0); });
+    });
+  });
+
 
   test('Configuration generation', () => {
     for (let n = 0; n < 10; n++) {

--- a/test/sudoku/SudokuSieve.test.js
+++ b/test/sudoku/SudokuSieve.test.js
@@ -258,10 +258,7 @@ describe('SudokuSieve', () => {
 
   describe('addFromMask', () => {
     test('finds all expected UAs containing 2 and 3 digits', () => {
-      expect(expectedSieveItemsByK[3]).toEqual(expect.arrayContaining(expectedSieveItemsByK[2]));
-
       let k = 2;
-
       let nck = nChooseK(DIGITS, k);
       for (let r = 0n; r < nck; r++) {
         const dCombo = Number(bitCombo(DIGITS, k, r));
@@ -302,29 +299,31 @@ describe('SudokuSieve', () => {
   });
 
   describe('add', () => {
-    describe('when items are not duplicate', () => {
-      test('adds items to the sieve and returns true', () => {
-        expect(sieve.add(306954992322430055219200n, ...expectedSieveItemsByK[2])).toBe(true);
-        expect(sieve.items).toEqual(expect.arrayContaining(expectedSieveItemsByK[2]));
+    test('adds item to the sieve and returns true ifoif not a duplicate', () => {
+      const expectedSieveLength = expectedSieveItemsByK[2].length;
+      expectedSieveItemsByK[2].forEach(item => {
+        expect(sieve.add(item)).toBe(true);
       });
+      expect(sieve.items.length).toBe(expectedSieveLength);
+      expect(sieve.items).toEqual(expect.arrayContaining(expectedSieveItemsByK[2]));
+
+      // Attempt to add duplicates.
+      // Expected to not add, returning false.
+      expectedSieveItemsByK[2].forEach(item => {
+        expect(sieve.add(item)).toBe(false);
+      });
+      expect(sieve.items.length).toBe(expectedSieveLength);
+      expect(sieve.items).toEqual(expect.arrayContaining(expectedSieveItemsByK[2]));
     });
 
-    describe('when given item is duplicate', () => {
-      test('does not add duplicate items and returns false', () => {
-        expect(sieve.add(...expectedSieveItemsByK[2])).toBe(true);
-        const lengthBefore = sieve.length;
-        expect(sieve.add(306954992322430055219200n)).toBe(false);
-        expect(sieve.length).toBe(lengthBefore);
-      });
-    });
-
-    describe('when items are derivatives', () => {
-      test('does not add the derivative and returns false', () => {
+    describe('when item is derivative', () => {
+      test('does not add the item and returns false', () => {
         const item = 306954992322430055219200n;
         sieve.add(item);
 
-        for (let t = 0; t < 100; t++) {
-          expect(sieve.add(item | randomBigInt(item))).toBe(false);
+        for (let t = 0; t < 10; t++) {
+          const derivative = (item | randomBigInt(item));
+          expect(sieve.add(derivative)).toBe(false);
         }
       });
     });


### PR DESCRIPTION
Resolves #40 

- Added `isValid` flag to sudoku instance.
`reduce(cell)` detects if the cell has no candidates available and sets the flag, halting the search.
The flag is reset when constraints are reset.
There is room for improvement - e.g. clearing the flag if setting digits removes the invalidity.

- Removed timeout arguments from solution search and config generation.
- Removed clunky results object from solution search.
- Added a couple test cases to cover the invalid search case from #40 